### PR TITLE
Range selection fix for first day of the week

### DIFF
--- a/calendarview2/src/main/java/com/ptrstovka/calendarview2/CalendarPagerView.java
+++ b/calendarview2/src/main/java/com/ptrstovka/calendarview2/CalendarPagerView.java
@@ -216,7 +216,6 @@ abstract class CalendarPagerView extends ViewGroup implements View.OnClickListen
             boolean isMiddleDayInRow = false;
             boolean isLastDayInRow = false;
 
-            int firstDayOfWeek = day.getCalendar().getFirstDayOfWeek();
             int lastDayOfWeek = firstDayOfWeek == Calendar.SUNDAY ?
                     Calendar.SATURDAY : Calendar.SUNDAY;
             int currentDayOfWeek = day.getCalendar().get(Calendar.DAY_OF_WEEK);


### PR DESCRIPTION
Range selection used calendar first day of the week rather than specified attribute.

![screenshot_1537956047](https://user-images.githubusercontent.com/5911414/46074301-0ee9a280-c17f-11e8-9daf-bd0ee9a686db.png)
![screenshot_1537956281](https://user-images.githubusercontent.com/5911414/46074302-0f823900-c17f-11e8-96b3-2675cea31503.png)
